### PR TITLE
refactor(lib): card bloc

### DIFF
--- a/lib/card/bloc/card_bloc.dart
+++ b/lib/card/bloc/card_bloc.dart
@@ -1,7 +1,6 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
-import 'package:mszakacz_card/card/logic/dimensions.dart';
-import 'package:mszakacz_card/constant/position.dart';
+import 'package:mszakacz_card/card/logic/click_card.dart';
 import 'package:mszakacz_card/models/window.dart';
 
 part 'card_event.dart';
@@ -11,54 +10,17 @@ class CardBloc extends Bloc<CardEvent, CardState> {
   CardBloc()
       : super(
           CardState(
-            windows: [
-              Window(
-                position: Position.largeBotRight,
-                top: botLargeWindowTop,
-                left: rightLargeWindowLeft,
-                size: largeWindowSize,
-                selected: true,
-              ),
-              Window(
-                position: Position.botLeft,
-                top: botRowPositionTop,
-                left: leftColumnPositionLeft,
-                size: smallWindowSize,
-                selected: false,
-              ),
-              Window(
-                position: Position.midLeft,
-                top: midRowPositionTop,
-                left: leftColumnPositionLeft,
-                size: smallWindowSize,
-                selected: false,
-              ),
-              Window(
-                position: Position.topLeft,
-                top: topRowPositionTop,
-                left: leftColumnPositionLeft,
-                size: smallWindowSize,
-                selected: false,
-              ),
-              Window(
-                position: Position.topCenter,
-                top: topRowPositionTop,
-                left: midColumnPositionLeft,
-                size: smallWindowSize,
-                selected: false,
-              ),
-              Window(
-                position: Position.topRight,
-                top: topRowPositionTop,
-                left: rightColumnPositionLeft,
-                size: smallWindowSize,
-                selected: false,
-              ),
-            ],
+            windows: clickCard(0),
           ),
         ) {
-    on<CardEvent>((event, emit) {
-      // TODO: implement event handler
-    });
+    on<TapWindow>(_onCardEvent);
+  }
+
+  void _onCardEvent(TapWindow event, Emitter<CardState> emit) {
+    emit(
+      state.copyWith(
+        windows: clickCard(event.clickedWindowIndex),
+      ),
+    );
   }
 }

--- a/lib/card/bloc/card_event.dart
+++ b/lib/card/bloc/card_event.dart
@@ -8,9 +8,9 @@ abstract class CardEvent extends Equatable {
 }
 
 class TapWindow extends CardEvent {
-  const TapWindow({required this.clickedWindow});
-  final Window clickedWindow;
+  const TapWindow({required this.clickedWindowIndex});
+  final int clickedWindowIndex;
 
   @override
-  List<Object> get props => [clickedWindow];
+  List<Object> get props => [clickedWindowIndex];
 }

--- a/lib/card/bloc/card_state.dart
+++ b/lib/card/bloc/card_state.dart
@@ -9,4 +9,12 @@ class CardState extends Equatable {
 
   @override
   List<Object> get props => [windows];
+
+  CardState copyWith({
+    List<Window>? windows,
+  }) {
+    return CardState(
+      windows: windows ?? this.windows,
+    );
+  }
 }


### PR DESCRIPTION
In this PR we:

- improve CardState by adding copyWith
- TapWindow event receive only windowIndex (int) as a parameter instead of whole window
- Improve CardBloc to emit a state with use of clickCard external method