### PR TITLE
refactor(card): refactor positions to be an enum

### DIFF
--- a/lib/card/bloc/card_state.dart
+++ b/lib/card/bloc/card_state.dart
@@ -3,18 +3,22 @@ part of 'card_bloc.dart';
 class CardState extends Equatable {
   const CardState({
     required this.windows,
+    required this.selected,
   });
 
-  final List<Window> windows;
+  final List<WindowPosition> windows;
+  final int selected;
 
   @override
-  List<Object> get props => [windows];
+  List<Object> get props => [windows, selected];
 
   CardState copyWith({
-    List<Window>? windows,
+    List<WindowPosition>? windows,
+    int? selected,
   }) {
     return CardState(
       windows: windows ?? this.windows,
+      selected: selected ?? this.selected,
     );
   }
 }

--- a/lib/card/logic/click_card.dart
+++ b/lib/card/logic/click_card.dart
@@ -1,61 +1,60 @@
 import 'package:mszakacz_card/constant/positions.dart';
-import 'package:mszakacz_card/models/window.dart';
 
-List<Window> clickCard(int clickedItem) {
+List<WindowPosition> clickCard(int clickedItem) {
   if (clickedItem == 0) {
     return [
-      largeTopLeft,
-      botLeft,
-      botCenter,
-      botRight,
-      midRight,
-      topRight,
+      WindowPosition.largeTopLeft,
+      WindowPosition.botLeft,
+      WindowPosition.botCenter,
+      WindowPosition.botRight,
+      WindowPosition.midRight,
+      WindowPosition.topRight,
     ];
   } else if (clickedItem == 1) {
     return [
-      topLeft,
-      largeBotLeft,
-      botRight,
-      midRight,
-      topRight,
-      topCenter,
+      WindowPosition.topLeft,
+      WindowPosition.largeBotLeft,
+      WindowPosition.botRight,
+      WindowPosition.midRight,
+      WindowPosition.topRight,
+      WindowPosition.topCenter,
     ];
   } else if (clickedItem == 2) {
     return [
-      topCenter,
-      topLeft,
-      largeBotLeft,
-      botRight,
-      midRight,
-      topRight,
+      WindowPosition.topCenter,
+      WindowPosition.topLeft,
+      WindowPosition.largeBotLeft,
+      WindowPosition.botRight,
+      WindowPosition.midRight,
+      WindowPosition.topRight,
     ];
   } else if (clickedItem == 3) {
     return [
-      topLeft,
-      midLeft,
-      botLeft,
-      largeBotRight,
-      topRight,
-      topCenter,
+      WindowPosition.topLeft,
+      WindowPosition.midLeft,
+      WindowPosition.botLeft,
+      WindowPosition.largeBotRight,
+      WindowPosition.topRight,
+      WindowPosition.topCenter,
     ];
   } else if (clickedItem == 4) {
     return [
-      midLeft,
-      botLeft,
-      botCenter,
-      botRight,
-      largeTopRight,
-      topLeft,
+      WindowPosition.midLeft,
+      WindowPosition.botLeft,
+      WindowPosition.botCenter,
+      WindowPosition.botRight,
+      WindowPosition.largeTopRight,
+      WindowPosition.topLeft,
     ];
   } else {
     // for clickedItem == 5
     return [
-      topLeft,
-      midLeft,
-      botLeft,
-      botCenter,
-      botRight,
-      largeTopRight,
+      WindowPosition.topLeft,
+      WindowPosition.midLeft,
+      WindowPosition.botLeft,
+      WindowPosition.botCenter,
+      WindowPosition.botRight,
+      WindowPosition.largeTopRight,
     ];
   }
 }

--- a/lib/card/view/card_page.dart
+++ b/lib/card/view/card_page.dart
@@ -27,43 +27,43 @@ class CardView extends StatelessWidget {
         return Stack(
           children: [
             WindowWidget(
-              window: state.windows[0],
+              windowPosition: state.windows[0],
               windowIndex: 0,
               child: const PictureWidget(),
             ),
             WindowWidget(
-              window: state.windows[1],
+              windowPosition: state.windows[1],
               windowIndex: 1,
-              child: state.windows[1].selected
+              child: state.selected == 1
                   ? const AnimatedNameWidget()
                   : const NameWidget(),
             ),
             WindowWidget(
-              window: state.windows[2],
+              windowPosition: state.windows[2],
               windowIndex: 2,
               child: AnimatedGoalsWidget(
-                selected: !state.windows[2].selected,
+                selected: state.selected != 2,
               ),
             ),
             WindowWidget(
-              window: state.windows[3],
+              windowPosition: state.windows[3],
               windowIndex: 3,
               child: AnimatedProjectsWidget(
-                selected: state.windows[3].selected,
+                selected: state.selected == 3,
               ),
             ),
             WindowWidget(
-              window: state.windows[4],
+              windowPosition: state.windows[4],
               windowIndex: 4,
               child: AnimatedLinksWidget(
-                selected: state.windows[4].selected,
+                selected: state.selected == 4,
               ),
             ),
             WindowWidget(
-              window: state.windows[5],
+              windowPosition: state.windows[5],
               windowIndex: 5,
               child: AnimatedHobbiesWidget(
-                selected: state.windows[5].selected,
+                selected: state.selected == 5,
               ),
             ),
           ],

--- a/lib/card/widgets/window_widget.dart
+++ b/lib/card/widgets/window_widget.dart
@@ -1,17 +1,22 @@
+// ignore_for_file: prefer_final_locals
+
+import 'dart:math';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mszakacz_card/card/bloc/card_bloc.dart';
-import 'package:mszakacz_card/models/window.dart';
+
+import 'package:mszakacz_card/constant/positions.dart';
 
 class WindowWidget extends StatefulWidget {
   const WindowWidget({
     Key? key,
-    required this.window,
+    required this.windowPosition,
     required this.child,
     required this.windowIndex,
   }) : super(key: key);
 
-  final Window window;
+  final WindowPosition windowPosition;
   final Widget child;
   final int windowIndex;
 
@@ -22,11 +27,72 @@ class WindowWidget extends StatefulWidget {
 class _WindowWidgetState extends State<WindowWidget> {
   @override
   Widget build(BuildContext context) {
+    //  Screen size
+    var screenWidth = MediaQuery.of(context).size.width;
+    var screenHeight = MediaQuery.of(context).size.height;
+    // Size of the grid
+    double containerSize = min(screenWidth, screenHeight);
+    var smallWindowSize = containerSize / 3;
+    var largeWindowSize = smallWindowSize * 2;
+
+    // Positions of the small windows
+    var topRowPositionTop = (screenHeight - containerSize) / 2;
+    var midRowPositionTop = topRowPositionTop + smallWindowSize;
+    var botRowPositionTop = topRowPositionTop + 2 * smallWindowSize;
+
+    var leftColumnPositionLeft = (screenWidth - containerSize) / 2;
+    var midColumnPositionLeft = leftColumnPositionLeft + smallWindowSize;
+    var rightColumnPositionLeft = leftColumnPositionLeft + 2 * smallWindowSize;
+
+    // Positions of the large windows
+    var topLargeWindowTop = topRowPositionTop;
+    var botLargeWindowTop = topRowPositionTop + smallWindowSize;
+
+    var leftLargeWindowLeft = leftColumnPositionLeft;
+    var rightLargeWindowLeft = leftColumnPositionLeft + smallWindowSize;
+
+    // Declaration of needed parameters
+    late double size;
+    late double top;
+    late double left;
+
+    // Statement related to WindowPosition
+
+    if (widget.windowPosition.toString().contains('large')) {
+      size = largeWindowSize;
+      if (widget.windowPosition.toString().contains('Left')) {
+        left = leftLargeWindowLeft;
+      } else if (widget.windowPosition.toString().contains('Right')) {
+        left = rightLargeWindowLeft;
+      }
+      if (widget.windowPosition.toString().contains('Top')) {
+        top = topLargeWindowTop;
+      } else if (widget.windowPosition.toString().contains('Bot')) {
+        top = botLargeWindowTop;
+      }
+    } else {
+      size = smallWindowSize;
+      if (widget.windowPosition.toString().contains('Left')) {
+        left = leftColumnPositionLeft;
+      } else if (widget.windowPosition.toString().contains('Center')) {
+        left = midColumnPositionLeft;
+      } else if (widget.windowPosition.toString().contains('Right')) {
+        left = rightColumnPositionLeft;
+      }
+      if (widget.windowPosition.toString().contains('top')) {
+        top = topRowPositionTop;
+      } else if (widget.windowPosition.toString().contains('mid')) {
+        top = midRowPositionTop;
+      } else if (widget.windowPosition.toString().contains('bot')) {
+        top = botRowPositionTop;
+      }
+    }
+
     return AnimatedPositioned(
-      width: widget.window.size,
-      height: widget.window.size,
-      top: widget.window.top,
-      left: widget.window.left,
+      width: size,
+      height: size,
+      top: top,
+      left: left,
       duration: const Duration(milliseconds: 500),
       child: GestureDetector(
         onTap: () => BlocProvider.of<CardBloc>(context).add(

--- a/lib/constant/positions.dart
+++ b/lib/constant/positions.dart
@@ -1,75 +1,14 @@
-import 'package:mszakacz_card/card/logic/dimensions.dart';
-import 'package:mszakacz_card/models/window.dart';
-
-final topLeft = Window(
-  top: topRowPositionTop,
-  left: leftColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final topCenter = Window(
-  top: topRowPositionTop,
-  left: midColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final topRight = Window(
-  top: topRowPositionTop,
-  left: rightColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final midLeft = Window(
-  top: midRowPositionTop,
-  left: leftColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final midRight = Window(
-  top: midRowPositionTop,
-  left: rightColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final botLeft = Window(
-  top: botRowPositionTop,
-  left: leftColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final botCenter = Window(
-  top: botRowPositionTop,
-  left: midColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final botRight = Window(
-  top: botRowPositionTop,
-  left: rightColumnPositionLeft,
-  size: smallWindowSize,
-  selected: false,
-);
-final largeTopLeft = Window(
-  top: topLargeWindowTop,
-  left: leftLargeWindowLeft,
-  size: largeWindowSize,
-  selected: true,
-);
-final largeTopRight = Window(
-  top: topLargeWindowTop,
-  left: rightLargeWindowLeft,
-  size: largeWindowSize,
-  selected: true,
-);
-final largeBotLeft = Window(
-  top: botLargeWindowTop,
-  left: leftLargeWindowLeft,
-  size: largeWindowSize,
-  selected: true,
-);
-final largeBotRight = Window(
-  top: botLargeWindowTop,
-  left: rightLargeWindowLeft,
-  size: largeWindowSize,
-  selected: true,
-);
+enum WindowPosition {
+  topLeft,
+  topCenter,
+  topRight,
+  midLeft,
+  midRight,
+  botLeft,
+  botCenter,
+  botRight,
+  largeTopLeft,
+  largeTopRight,
+  largeBotLeft,
+  largeBotRight,
+}


### PR DESCRIPTION
In this PR we:
- refactor positions.dart to be an enum instead of object which contains dimensions,
- change clickCard method to return a list of enums instead of list of windows dimensions,
- move dimension calculation to WindowWidget (purpose: use of MediaQuery),
- change CardPage to pass the WindowPosition (enum) instead of Window (object with dimensions),
- change the CardState property to List of WindowPosition (enum) instead of List of Windows (object with dimensions).